### PR TITLE
Add docker config env to use docker authen

### DIFF
--- a/tekton/tasks/source-to-image.yaml
+++ b/tekton/tasks/source-to-image.yaml
@@ -22,6 +22,9 @@ spec:
   steps:
     - name: build-and-push
       image: gcr.io/kaniko-project/executor
+      env:
+      - name: DOCKER_CONFIG
+        value: /builder/home/.docker      
       command:
         - /kaniko/executor
       args:


### PR DESCRIPTION
kaniko needs DOCKER_CONFIG env pointing to .docker to perform docker registry authentication