### PR TITLE
fix #7, typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,72 +2,68 @@
 
 Tekton is an open source project to configure and run CI/CD pipelines within a Kubernetes cluster.
 
-
 ## Introduction
 
 In this tutorial you'll learn
-* what are the basic concepts used by Tekton pipelines
-* how to create a pipeline to build and deploy a container
-* how to run the pipeline, check its status and troubleshoot problems
 
+- what are the basic concepts used by Tekton pipelines
+- how to create a pipeline to build and deploy a container
+- how to run the pipeline, check its status and troubleshoot problems
 
 ## Prerequisites
 
 Before you start the tutorial you must set up a Kubernetes environment with Tekton installed.
 
-* [Install the CLIs to manage a cluster](https://cloud.ibm.com/docs/containers?topic=containers-cs_cli_install#cs_cli_install_steps)
+- [Install the CLIs to manage a cluster](https://cloud.ibm.com/docs/containers?topic=containers-cs_cli_install#cs_cli_install_steps)
 
-* [Create a standard Kubernetes cluster in IBM Kubernetes Service](https://cloud.ibm.com/docs/containers?topic=containers-clusters#clusters_ui_standard)
+- [Create a standard Kubernetes cluster in IBM Kubernetes Service](https://cloud.ibm.com/docs/containers?topic=containers-clusters#clusters_ui_standard)
 
-    **Note**:
-    * Tekton requires Kubernetes version 1.15 or higher.
-    * The tutorial uses a standard cluster because it supports dynamic provisioning of storage volumes.
+  **Note**:
 
-* [Create a private container registry in IBM Container Service](https://cloud.ibm.com/docs/services/Registry?topic=registry-registry_setup_cli_namespace#registry_setup_cli_namespace)
+  - Tekton requires Kubernetes version 1.15 or higher.
+  - The tutorial uses a standard cluster because it supports dynamic provisioning of storage volumes.
 
-* Install Tekton in your cluster.  This tutorial was written using Tekton version 0.11.1.  If you use a later version you may encounter some functional differences.
+- [Create a private container registry in IBM Container Service](https://cloud.ibm.com/docs/services/Registry?topic=registry-registry_setup_cli_namespace#registry_setup_cli_namespace)
 
-    ```
-    kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.11.1/release.yaml
-    ```
+- Install Tekton in your cluster. This tutorial was written using Tekton version 0.11.1. If you use a later version you may encounter some functional differences.
 
-    Monitor the installation using the following command until all components show a Running status:
+  ```
+  kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.11.1/release.yaml
+  ```
 
-    ```
-    kubectl get pods --namespace tekton-pipelines --watch
-    ```
+  Monitor the installation using the following command until all components show a Running status:
 
-* [Install the Tekton Pipelines CLI](https://github.com/tektoncd/cli#installing-tkn)
+  ```
+  kubectl get pods --namespace tekton-pipelines --watch
+  ```
 
+- [Install the Tekton Pipelines CLI](https://github.com/tektoncd/cli#installing-tkn)
 
 ## Estimated time
 
 1 hour
 
-
 ## Steps
-
 
 ### 1. Tekton pipeline concepts
 
 Tekton provides a set of extensions to Kubernetes, in the form of [Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/), for defining pipelines.
-The following diagram shows the resources used in this tutorial.  The arrows depict references from one resource to another resource.
+The following diagram shows the resources used in this tutorial. The arrows depict references from one resource to another resource.
 
 ![crd](doc/source/images/crd.png)
 
 The resources are used as follows.
 
-* A **PipelineRun** defines an execution of a pipeline.  It references the **Pipeline** to run.
-* A **Pipeline** defines the set of **Tasks** that compose a pipeline.
-* A **Task** defines a set of build steps such as compiling code, running tests, and building and deploying images.
+- A **PipelineRun** defines an execution of a pipeline. It references the **Pipeline** to run.
+- A **Pipeline** defines the set of **Tasks** that compose a pipeline.
+- A **Task** defines a set of build steps such as compiling code, running tests, and building and deploying images.
 
 We will go into more detail about each resource during the walkthrough of the example.
 
 Let's create a simple pipeline that
 
-* builds a Docker image from source files and pushes it to your private container registry
-* deploys the image to your Kubernetes cluster
-
+- builds a Docker image from source files and pushes it to your private container registry
+- deploys the image to your Kubernetes cluster
 
 ### 2. Clone the repository
 
@@ -82,7 +78,6 @@ git checkout beta-update
 We will work from the bottom-up, i.e. first we will define the Task resources needed to build and deploy the image,
 then we'll define the Pipeline resource that references the tasks,
 and finally we'll create the PipelineRun resource needed to run the pipeline.
-
 
 ### 3. Create a task to clone the Git repository
 
@@ -107,7 +102,7 @@ spec:
     description: git url to clone
     type: string
   - name: revision
-    description: git revision to checkout (branch, tag, sha, ref…)
+    description: git revision to checkout (branch, tag, sha, refï¿½)
     type: string
     default: master
   - name: submodules
@@ -176,13 +171,14 @@ spec:
       echo -n "$RESULT_SHA" > $(results.commit.path)
 ```
 
-A task can have one or more steps.  Each step defines an image to run to perform the function of the step.
+A task can have one or more steps. Each step defines an image to run to perform the function of the step.
 This task has one step that uses a Tekton-provided container to clone a Git repo.
 
-A task can have parameters.  Parameters help to make a task reusable.
+A task can have parameters. Parameters help to make a task reusable.
 This task accepts many parameters such as:
-* the URL of the Git repository to clone
-* the revision to check out
+
+- the URL of the Git repository to clone
+- the revision to check out
 
 Parameters can have default values provided by the task or the values can be provided by the `Pipeline` and `PipelineRun` resources that we'll see later.
 Steps can reference parameter values by using the syntax `$(params.name)` where `name` is the name of the parameter.
@@ -198,7 +194,6 @@ Apply the file to your cluster to create the task.
 ```
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/git/git-clone.yaml
 ```
-
 
 ### 4. Create a task to build an image and push it to a container registry
 
@@ -283,9 +278,8 @@ This will be covered later on in the tutorial.
 Apply the file to your cluster to create the task.
 
 ```
-https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kaniko/kaniko.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kaniko/kaniko.yaml
 ```
-
 
 ### 5. Create a task to deploy an image to a Kubernetes cluster
 
@@ -335,7 +329,7 @@ spec:
 This task has two steps.
 
 1. The first step runs `sed` in an Alpine Linux container to update the yaml file used for deployment with the image that was built by the `kaniko` task.
-The step requires the yaml file to have two character strings, `__IMAGE__` and `__DIGEST__`, which are substituted with parameter values.
+   The step requires the yaml file to have two character strings, `__IMAGE__` and `__DIGEST__`, which are substituted with parameter values.
 
 2. The second step runs `kubectl` using Lachlan Evenson's popular `k8s-kubectl` container image to apply the yaml file to the same cluster where the pipeline is running.
 
@@ -350,7 +344,6 @@ Apply the file to your cluster to create the task.
 ```
 kubectl apply -f tekton/tasks/deploy-using-kubectl.yaml
 ```
-
 
 ### 6. Create a pipeline
 
@@ -424,11 +417,11 @@ spec:
 ```
 
 A Pipeline resource contains a list of tasks to run.
-Each pipeline task is assigned a `name` within the pipeline;  here they are `clone-repo`, `source-to-image`, and `deploy-using-kubectl`.
+Each pipeline task is assigned a `name` within the pipeline; here they are `clone-repo`, `source-to-image`, and `deploy-using-kubectl`.
 
 The pipeline configures each task via the task's parameters.
 You can choose whether to expose a task parameter as a pipeline parameter, set the value directly, or let the value
-default inside the task (if it's an optional parameter).  For example this pipeline exposes the `CONTEXT` parameter from the
+default inside the task (if it's an optional parameter). For example this pipeline exposes the `CONTEXT` parameter from the
 kaniko task (under a different name, `pathToContext`) but does not expose the `DOCKERFILE` parameter and allows it to default inside the task.
 
 This pipeline also shows how to take the result of one task and pass it to another task.
@@ -444,14 +437,13 @@ In this example, the pipeline specifies that the `source-to-image` pipeline task
 
 The `deploy-using-kubectl` pipeline task must run after the `source-to-image` pipeline task but it doesn't need to specify the `runAfter` key.
 This is because it references a task result from the `source-to-image` pipeline task
-and Tekton is smart enough to figure out that this means it must run after that task. 
+and Tekton is smart enough to figure out that this means it must run after that task.
 
 Apply the file to your cluster to create the pipeline.
 
 ```
 kubectl apply -f tekton/pipeline/build-and-deploy-pipeline.yaml
 ```
-
 
 ### 7. Define a service account
 
@@ -472,8 +464,8 @@ kubectl annotate secret ibm-registry-secret tekton.dev/docker-0=<REGISTRY>
 
 where
 
-* `<APIKEY>` is either the API key that you created
-* `<REGISTRY>` is the domain name of your container registry, such as `us.icr.io` (you can find out the domain name of your registry using the command `ibmcloud cr region`)
+- `<APIKEY>` is either the API key that you created
+- `<REGISTRY>` is the domain name of your container registry, such as `us.icr.io` (you can find out the domain name of your registry using the command `ibmcloud cr region`)
 
 This secret will be used to both push and pull images from your registry.
 
@@ -529,22 +521,21 @@ subjects:
 
 This yaml creates the following Kubernetes resources:
 
-* A ServiceAccount named `pipeline-account`.
-The service account references the `ibm-registry-secret` secret so that the pipeline can authenticate to your private container registry
-when it pushes and pulls a container image.
+- A ServiceAccount named `pipeline-account`.
+  The service account references the `ibm-registry-secret` secret so that the pipeline can authenticate to your private container registry
+  when it pushes and pulls a container image.
 
-* A Secret named `kube-api-secret` which contains an API credential (generated by Kubernetes) for accessing the Kubernetes API.
-This allows the pipeline to use `kubectl` to talk to your cluster.
+- A Secret named `kube-api-secret` which contains an API credential (generated by Kubernetes) for accessing the Kubernetes API.
+  This allows the pipeline to use `kubectl` to talk to your cluster.
 
-* A Role named `pipeline-role` and a RoleBinding named `pipeline-role-binding` which provide the resource-based access control permissions
-needed for this pipeline to create and modify Kubernetes resources.
+- A Role named `pipeline-role` and a RoleBinding named `pipeline-role-binding` which provide the resource-based access control permissions
+  needed for this pipeline to create and modify Kubernetes resources.
 
 Apply the file to your cluster to create the service account and related resources.
 
 ```
 kubectl apply -f tekton/pipeline-account.yaml
 ```
-
 
 ### 8. Create a PipelineRun
 
@@ -578,27 +569,27 @@ spec:
         claimName: picalc-source-pvc
 ```
 
-Although this file is small there is a lot going on here.  Let's break it down from top to bottom:
+Although this file is small there is a lot going on here. Let's break it down from top to bottom:
 
-* The PipelineRun does not have a fixed name.  It uses `generateName` to generate a name each time it is created.
-This is because a particular PipelineRun resource executes the pipeline only once.  If you want to run the pipeline again,
-you cannot modify an existing PipelineRun resource to request it to re-run -- you must create a new PipelineRun resource.
-While you could use `name` to assign a unique name to your PipelineRun each time you create one, it is much easier to use `generateName`.
+- The PipelineRun does not have a fixed name. It uses `generateName` to generate a name each time it is created.
+  This is because a particular PipelineRun resource executes the pipeline only once. If you want to run the pipeline again,
+  you cannot modify an existing PipelineRun resource to request it to re-run -- you must create a new PipelineRun resource.
+  While you could use `name` to assign a unique name to your PipelineRun each time you create one, it is much easier to use `generateName`.
 
-* The Pipeline resource is identified under the `pipelineRef` key.
+- The Pipeline resource is identified under the `pipelineRef` key.
 
-* Parameters exposed by the pipeline are set to specific values such as the Git repository to clone, the image to build, and the yaml file to deploy.
-This example builds a [go program that calculates an approximation of pi](src/picalc.go).
-The source includes a [Dockerfile](src/Dockerfile) which runs tests, compiles the code, and builds an image for execution.
+- Parameters exposed by the pipeline are set to specific values such as the Git repository to clone, the image to build, and the yaml file to deploy.
+  This example builds a [go program that calculates an approximation of pi](src/picalc.go).
+  The source includes a [Dockerfile](src/Dockerfile) which runs tests, compiles the code, and builds an image for execution.
 
-    You must edit the `picalc-pipeline-run.yaml` file to substitute the values of `<REGISTRY>` and `<NAMESPACE>` with the information for your private container registry.
+      You must edit the `picalc-pipeline-run.yaml` file to substitute the values of `<REGISTRY>` and `<NAMESPACE>` with the information for your private container registry.
 
-    * To find the value for `<REGISTRY>`, enter the command `ibmcloud cr region`.
-    * To find the value for `<NAMESPACE>`, enter the command `ibmcloud cr namespace-list`.
+      * To find the value for `<REGISTRY>`, enter the command `ibmcloud cr region`.
+      * To find the value for `<NAMESPACE>`, enter the command `ibmcloud cr namespace-list`.
 
-* The service account named `pipeline-account` which we created earlier is specified to provide the credentials needed for the pipeline to run successfully.
+- The service account named `pipeline-account` which we created earlier is specified to provide the credentials needed for the pipeline to run successfully.
 
-* The workspace used by the pipeline to clone the Git repository is mapped to a persistent volume claim which is a request for a storage volume.
+- The workspace used by the pipeline to clone the Git repository is mapped to a persistent volume claim which is a request for a storage volume.
 
 Before you run the pipeline for the first time, you must create the persistent volume claim for the workspace.
 
@@ -618,7 +609,6 @@ NAME                STATUS   VOLUME                                     CAPACITY
 picalc-source-pvc   Bound    pvc-662946bc-57f2-4ba5-982c-b0fa9db1d065   20Gi       RWO            ibmc-file-bronze   2m
 ```
 
-
 ### 9. Run the pipeline
 
 All the pieces are in place to run the pipeline.
@@ -636,7 +626,7 @@ Let's use the `tkn` CLI to check the status of the PipelineRun.
 While you can check the status of the pipeline using the `kubectl describe` command, the `tkn` cli provides much nicer output.
 
 ```
-$ tkn pipelinerun describe picalc-pr-c7hsb 
+$ tkn pipelinerun describe picalc-pr-c7hsb
 Name:              picalc-pr-c7hsb
 Namespace:         default
 Pipeline Ref:      build-and-deploy-pipeline
@@ -666,10 +656,10 @@ Taskruns
  picalc-pr-c7hsb-clone-repo-pvbsk        clone-repo        2 minutes ago    1 minute   Succeeded
 ```
 
-This tells us that the pipeline is running. 
+This tells us that the pipeline is running.
 The `clone-repo` pipeline task has completely successfully and the `source-to-image` pipeline task is currently running.
 
-Continue to rerun the command to check the status.  If the pipeline runs successfully, the description eventually should look like this:
+Continue to rerun the command to check the status. If the pipeline runs successfully, the description eventually should look like this:
 
 ```
 $ tkn pipelinerun describe picalc-pr-c7hsb
@@ -703,7 +693,7 @@ Taskruns
  picalc-pr-c7hsb-clone-repo-pvbsk          clone-repo          12 minutes ago   1 minute     Succeeded
 ```
 
-Check the status of the Kubernetes deployment.  It should be ready.
+Check the status of the Kubernetes deployment. It should be ready.
 
 ```
 $ kubectl get deploy picalc
@@ -772,7 +762,7 @@ Taskruns
  picalc-pr-sk7md-clone-repo-8gs25   clone-repo   2 minutes ago   41 seconds   Failed
 ```
 
-The output tells us that the `clone-repo` pipeline task failed.  The `Message` also tells us how to get the logs from the pod which was used to run the task:
+The output tells us that the `clone-repo` pipeline task failed. The `Message` also tells us how to get the logs from the pod which was used to run the task:
 
 ```
 for logs run: kubectl -n default logs picalc-pr-sk7md-clone-repo-8gs25-pod-v7fg8 -c step-clone
@@ -794,16 +784,11 @@ You can also get the logs for the last PipelineRun for a particular Pipeline usi
 tkn pipeline logs build-and-deploy-pipeline -L
 ```
 
-You should delete a PipelineRun when you no longer have a need to reference its logs.  Deleting the PipelineRun deletes the pods that were used
+You should delete a PipelineRun when you no longer have a need to reference its logs. Deleting the PipelineRun deletes the pods that were used
 to run the pipeline tasks.
-
 
 ## Summary
 
 Tekton provides simple, easy-to-learn features for constructing CI/CD pipelines that run on Kubernetes.
 This tutorial covered the basics to get you started building your own pipelines.
 There are more features available and many more planned for upcoming releases.
-
-
-
-


### PR DESCRIPTION
Only one change: append `kubectl apply -f` to the command mentioned in #7 
The rest of the changes are by a standard markdown linter.